### PR TITLE
Add fixup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ device.
 ## Todo
 
 - [ ] transcribe all 297 pages
-- [ ] correct CP1252/CP437 transliteration errors
-  - [ ] ...with a programmatic transformation step
-- [ ] correct column 72 / column 80 wrapping errors
-  - [ ] ...with a programmatic transformation step
+- [x] correct CP1252/CP437 transliteration errors
+  - [x] ...with a programmatic transformation step
+- [x] correct column 72 / column 80 wrapping errors
+  - [x] ...with a programmatic transformation step
 - [ ] identify an assembler that can (attempt to) compile the source
 - [ ] figure out what kind of license makes sense for this..?

--- a/codefix.py
+++ b/codefix.py
@@ -1,0 +1,57 @@
+# This tool can be used to correct the codepage/line width mismatch seen in the scanned code.
+# By SopaXorzTaker
+
+from sys import argv
+
+if not len(argv) == 3:
+    print "Usage: %s <source-file> <destination-file>" % argv[0]
+    exit(1)
+
+with open(argv[1], "r") as infile:
+    lines = infile.readlines()
+
+    # We have to convert UTF8 to Windows-1252 first.
+    # Then we re-interpret that as CP437.
+    # The trailing spaces and line breaks are removed.
+
+    lines = map(lambda x: x.decode("utf-8").encode("windows-1252").decode("cp437").rstrip(), lines)
+
+    # Now we look for wrapped lines and unwrap them
+    i = 0
+    new_lines = []
+
+    # Fix 80-line text printed in 72
+    while i < len(lines):
+        line = lines[i]
+
+        # Remove tabs
+        sline = line.replace("   ", "")
+
+        # Remove the page numbers (effectively skipping page breaks)
+        if line.lstrip().startswith("A-"):
+            i += 2
+            pass
+
+        # If the line is too long, it has been wrapped.
+        elif len(sline) > 73 and i + 1 < len(lines):
+            line += lines[i+1]
+            new_lines.append(line)
+            i += 2
+
+        # If the line started with a box-drawing character, it should be prepended back.
+        elif line and ord(line[0]) > 127 and len(new_lines) > 0:
+            sep = " " * (79 - len(new_lines[-1]) - len(line))
+
+            new_lines[-1] += sep + line
+            i += 1
+
+        # Just append the next line
+        else:
+            new_lines.append(line)
+            i += 1
+
+    # Write the output
+    with open(argv[2], "w") as outfile:
+        new_text = "\n".join(new_lines).encode("utf-8")
+
+        outfile.write(new_text)

--- a/codefix.py
+++ b/codefix.py
@@ -21,7 +21,7 @@ with open(argv[1], "r") as infile:
     i = 0
     new_lines = []
 
-    # Fix 80-line text printed in 72
+    # Fix 80-column text printed in 72
     while i < len(lines):
         line = lines[i]
 

--- a/codefix.py
+++ b/codefix.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # This tool can be used to correct the codepage/line width mismatch seen in the scanned code.
 # By SopaXorzTaker
 


### PR DESCRIPTION
I wrote a small tool to automatically correct the codepage/line width mismatch. It isn't perfect, but does work for the manually OCRed file.